### PR TITLE
feat: 스프링 Security 기반 로그인 및 인증 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,11 @@ dependencies {
 
 	//쿼리 파라미터 로그 라이브러리
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
+
+	//JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
+			'io.jsonwebtoken:jjwt-jackson:0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/coalba/domain/auth/config/SecurityConfig.java
+++ b/src/main/java/com/project/coalba/domain/auth/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.project.coalba.domain.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(securedEnabled = true)
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors().and().csrf().disable()
+                .headers().frameOptions().disable()
+                .and()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and().formLogin().disable()
+                .httpBasic().disable()
+                .authorizeRequests()
+                .antMatchers("/", "/error", "/css/**", "/images/**", "/js/**", "/auth/**").permitAll()
+                .antMatchers("/boss/**").hasRole("BOSS")
+                .antMatchers("/staff/**").hasRole("STAFF")
+                .anyRequest().authenticated()
+                .and()
+                .oauth2Login().disable();
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/project/coalba/domain/auth/config/SecurityConfig.java
+++ b/src/main/java/com/project/coalba/domain/auth/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.project.coalba.domain.auth.config;
 
+import com.project.coalba.domain.auth.filter.JwtAuthenticationEntryPoint;
+import com.project.coalba.domain.auth.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -7,11 +10,16 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+@RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -28,8 +36,11 @@ public class SecurityConfig {
                 .antMatchers("/staff/**").hasRole("STAFF")
                 .anyRequest().authenticated()
                 .and()
+                .exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .and()
                 .oauth2Login().disable();
 
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/com/project/coalba/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/project/coalba/domain/auth/controller/AuthController.java
@@ -1,0 +1,21 @@
+package com.project.coalba.domain.auth.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/auth")
+@RestController
+public class AuthController {
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login() {
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<Void> refresh() {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/project/coalba/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/project/coalba/domain/auth/controller/AuthController.java
@@ -1,21 +1,28 @@
 package com.project.coalba.domain.auth.controller;
 
+import com.project.coalba.domain.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RequestMapping("/auth")
 @RestController
 public class AuthController {
 
+    private final AuthService authService;
+
     @PostMapping("/login")
     public ResponseEntity<Void> login() {
+        authService.login();
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/refresh")
     public ResponseEntity<Void> refresh() {
+        authService.reissue();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/project/coalba/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/project/coalba/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.project.coalba.domain.auth.controller;
 
+import com.project.coalba.domain.auth.dto.response.AuthResponse;
 import com.project.coalba.domain.auth.entity.enums.Provider;
 import com.project.coalba.domain.auth.entity.enums.Role;
 import com.project.coalba.domain.auth.service.AuthService;
@@ -18,9 +19,8 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<Void> login(@RequestParam Provider provider, @RequestParam String token, @RequestParam Role role) {
-        authService.login(provider, token, role);
-        return ResponseEntity.ok().build();
+    public AuthResponse login(@RequestParam Provider provider, @RequestParam String token, @RequestParam Role role) {
+        return authService.login(provider, token, role);
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/project/coalba/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/project/coalba/domain/auth/controller/AuthController.java
@@ -1,10 +1,13 @@
 package com.project.coalba.domain.auth.controller;
 
+import com.project.coalba.domain.auth.entity.enums.Provider;
+import com.project.coalba.domain.auth.entity.enums.Role;
 import com.project.coalba.domain.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -15,8 +18,8 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<Void> login() {
-        authService.login();
+    public ResponseEntity<Void> login(@RequestParam Provider provider, @RequestParam String token, @RequestParam Role role) {
+        authService.login(provider, token, role);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/project/coalba/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/project/coalba/domain/auth/controller/AuthController.java
@@ -1,15 +1,15 @@
 package com.project.coalba.domain.auth.controller;
 
+import com.project.coalba.domain.auth.dto.request.TokenRequest;
 import com.project.coalba.domain.auth.dto.response.AuthResponse;
+import com.project.coalba.domain.auth.dto.response.TokenResponse;
 import com.project.coalba.domain.auth.entity.enums.Provider;
 import com.project.coalba.domain.auth.entity.enums.Role;
 import com.project.coalba.domain.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/auth")
@@ -24,8 +24,9 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<Void> refresh() {
-        authService.reissue();
-        return ResponseEntity.ok().build();
+    public ResponseEntity<TokenResponse> refresh(@RequestBody TokenRequest tokenRequest) {
+        TokenResponse tokenResponse = authService.reissue(tokenRequest.getAccessToken(), tokenRequest.getRefreshToken());
+        HttpStatus status = (tokenResponse == null) ? HttpStatus.UNAUTHORIZED : HttpStatus.OK;
+        return ResponseEntity.status(status).body(tokenResponse);
     }
 }

--- a/src/main/java/com/project/coalba/domain/auth/dto/GoogleUserInfoDto.java
+++ b/src/main/java/com/project/coalba/domain/auth/dto/GoogleUserInfoDto.java
@@ -1,0 +1,14 @@
+package com.project.coalba.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleUserInfoDto {
+
+    private String id;
+    private String email;
+    private String name;
+    private String picture;
+}

--- a/src/main/java/com/project/coalba/domain/auth/dto/NaverUserInfoDto.java
+++ b/src/main/java/com/project/coalba/domain/auth/dto/NaverUserInfoDto.java
@@ -1,0 +1,23 @@
+package com.project.coalba.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverUserInfoDto {
+
+    private Response response;
+
+    @Getter
+    public static class Response {
+
+        private String id;
+        private String email;
+        private String name;
+        @JsonProperty(value = "profile_image")
+        private String profileImage;
+    }
+}
+

--- a/src/main/java/com/project/coalba/domain/auth/dto/request/TokenRequest.java
+++ b/src/main/java/com/project/coalba/domain/auth/dto/request/TokenRequest.java
@@ -1,0 +1,10 @@
+package com.project.coalba.domain.auth.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class TokenRequest {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/project/coalba/domain/auth/dto/response/AuthResponse.java
+++ b/src/main/java/com/project/coalba/domain/auth/dto/response/AuthResponse.java
@@ -1,0 +1,12 @@
+package com.project.coalba.domain.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter @Builder
+public class AuthResponse {
+
+    private String accessToken;
+    private String refreshToken;
+    private Boolean isNewUser;
+}

--- a/src/main/java/com/project/coalba/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/project/coalba/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.project.coalba.domain.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter @Builder
+public class TokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/project/coalba/domain/auth/entity/User.java
+++ b/src/main/java/com/project/coalba/domain/auth/entity/User.java
@@ -36,4 +36,11 @@ public class User extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String providerId;
+
+    public void updateSocialInfo(User user) {
+        this.email = user.getEmail();
+        this.name = user.getName();
+        this.imageUrl = user.getImageUrl();
+        this.providerId = user.getProviderId();
+    }
 }

--- a/src/main/java/com/project/coalba/domain/auth/entity/UserPrincipal.java
+++ b/src/main/java/com/project/coalba/domain/auth/entity/UserPrincipal.java
@@ -1,0 +1,61 @@
+package com.project.coalba.domain.auth.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter @Builder
+public class UserPrincipal implements UserDetails {
+
+    private final Long userId;
+    private final String providerId;
+    private final Collection<GrantedAuthority> authorities;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return providerId;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public static UserPrincipal create(User user) {
+        return UserPrincipal.builder()
+                .userId(user.getId())
+                .providerId(user.getProviderId())
+                .authorities(Collections.singletonList(new SimpleGrantedAuthority(user.getRole().getCode())))
+                .build();
+    }
+}

--- a/src/main/java/com/project/coalba/domain/auth/entity/UserRefreshToken.java
+++ b/src/main/java/com/project/coalba/domain/auth/entity/UserRefreshToken.java
@@ -8,22 +8,22 @@ import javax.persistence.*;
 @Getter @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "refresh_token")
 @Entity
-public class RefreshToken extends BaseTimeEntity {
+public class UserRefreshToken extends BaseTimeEntity {
 
     @Id
-    @Column(name = "token_key")
-    private Long key;
+    @Column(name = "refresh_token_id")
+    private Long id;
 
     @MapsId
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "token_key")
+    @JoinColumn(name = "refresh_token_id")
     private User user; //FK이면서 PK
 
-    @Column(name = "token_value")
-    private String value;
+    private String token;
 
-    public void updateValue(String value) {
-        this.value = value;
+    public void updateToken(String token) {
+        this.token = token;
     }
 }

--- a/src/main/java/com/project/coalba/domain/auth/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/project/coalba/domain/auth/filter/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package com.project.coalba.domain.auth.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.error("Responding with unauthorized error. Message = {}", authException.getMessage());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write(authException.getLocalizedMessage());
+    }
+}

--- a/src/main/java/com/project/coalba/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/coalba/domain/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,35 @@
+package com.project.coalba.domain.auth.filter;
+
+import com.project.coalba.domain.auth.token.AuthTokenManager;
+import com.project.coalba.domain.auth.utils.HeaderUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final AuthTokenManager tokenManager;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = HeaderUtil.getAccessToken(request);
+        if (tokenManager.validate(token)) {
+            Authentication authentication = tokenManager.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication); //인증된 사용자 정보 Security Context에 저장
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/project/coalba/domain/auth/info/UserInfo.java
+++ b/src/main/java/com/project/coalba/domain/auth/info/UserInfo.java
@@ -1,0 +1,9 @@
+package com.project.coalba.domain.auth.info;
+
+import com.project.coalba.domain.auth.entity.User;
+import com.project.coalba.domain.auth.entity.enums.Role;
+
+public interface UserInfo {
+
+    User getUser(String token, Role role);
+}

--- a/src/main/java/com/project/coalba/domain/auth/info/UserInfoFactory.java
+++ b/src/main/java/com/project/coalba/domain/auth/info/UserInfoFactory.java
@@ -1,0 +1,16 @@
+package com.project.coalba.domain.auth.info;
+
+import com.project.coalba.domain.auth.entity.enums.Provider;
+import com.project.coalba.domain.auth.info.impl.GoogleUserInfo;
+import com.project.coalba.domain.auth.info.impl.NaverUserInfo;
+
+public abstract class UserInfoFactory {
+
+    public static UserInfo getUserInfo(Provider provider) {
+        switch (provider) {
+            case GOOGLE: return new GoogleUserInfo();
+            case NAVER: return new NaverUserInfo();
+            default: throw new IllegalArgumentException("Invalid Provider Type.");
+        }
+    }
+}

--- a/src/main/java/com/project/coalba/domain/auth/info/impl/GoogleUserInfo.java
+++ b/src/main/java/com/project/coalba/domain/auth/info/impl/GoogleUserInfo.java
@@ -1,0 +1,42 @@
+package com.project.coalba.domain.auth.info.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.coalba.domain.auth.dto.GoogleUserInfoDto;
+import com.project.coalba.domain.auth.entity.User;
+import com.project.coalba.domain.auth.entity.enums.Provider;
+import com.project.coalba.domain.auth.entity.enums.Role;
+import com.project.coalba.domain.auth.info.UserInfo;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.net.URL;
+
+@Slf4j
+public class GoogleUserInfo implements UserInfo {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public User getUser(String token, Role role) {
+        GoogleUserInfoDto googleUserInfoDto = getGoogleUserInfoDto(token);
+        return User.builder()
+                .email(googleUserInfoDto.getEmail())
+                .name(googleUserInfoDto.getName())
+                .imageUrl(googleUserInfoDto.getPicture())
+                .role(role)
+                .provider(Provider.GOOGLE)
+                .providerId(googleUserInfoDto.getId())
+                .build();
+    }
+
+    private GoogleUserInfoDto getGoogleUserInfoDto(String token) {
+        try {
+            String reqURL = "https://www.googleapis.com/oauth2/v1/userinfo?access_token=" + token;
+            URL url = new URL(reqURL);
+            return mapper.readValue(url, GoogleUserInfoDto.class);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+        }
+        throw new IllegalArgumentException("Invalid Token.");
+    }
+}

--- a/src/main/java/com/project/coalba/domain/auth/info/impl/NaverUserInfo.java
+++ b/src/main/java/com/project/coalba/domain/auth/info/impl/NaverUserInfo.java
@@ -1,0 +1,42 @@
+package com.project.coalba.domain.auth.info.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.coalba.domain.auth.dto.NaverUserInfoDto;
+import com.project.coalba.domain.auth.entity.User;
+import com.project.coalba.domain.auth.entity.enums.Provider;
+import com.project.coalba.domain.auth.entity.enums.Role;
+import com.project.coalba.domain.auth.info.UserInfo;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.net.URL;
+
+@Slf4j
+public class NaverUserInfo implements UserInfo {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public User getUser(String token, Role role) {
+        NaverUserInfoDto naverUserInfoDto = getNaverUserInfoDto(token);
+        return User.builder()
+                .email(naverUserInfoDto.getResponse().getEmail())
+                .name(naverUserInfoDto.getResponse().getName())
+                .imageUrl(naverUserInfoDto.getResponse().getProfileImage())
+                .role(role)
+                .provider(Provider.NAVER)
+                .providerId(naverUserInfoDto.getResponse().getId())
+                .build();
+    }
+
+    private NaverUserInfoDto getNaverUserInfoDto(String token) {
+        try {
+            String reqURL = "https://openapi.naver.com/v1/nid/me?access_token=" + token;
+            URL url = new URL(reqURL);
+            return mapper.readValue(url, NaverUserInfoDto.class);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+        }
+        throw new IllegalArgumentException("Invalid Token.");
+    }
+}

--- a/src/main/java/com/project/coalba/domain/auth/repository/UserRefreshTokenRepository.java
+++ b/src/main/java/com/project/coalba/domain/auth/repository/UserRefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.project.coalba.domain.auth.repository;
+
+import com.project.coalba.domain.auth.entity.UserRefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
+}

--- a/src/main/java/com/project/coalba/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/project/coalba/domain/auth/repository/UserRepository.java
@@ -3,5 +3,9 @@ package com.project.coalba.domain.auth.repository;
 import com.project.coalba.domain.auth.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByProviderId(String providerId);
 }

--- a/src/main/java/com/project/coalba/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/project/coalba/domain/auth/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.project.coalba.domain.auth.repository;
+
+import com.project.coalba.domain.auth.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/project/coalba/domain/auth/service/AuthService.java
+++ b/src/main/java/com/project/coalba/domain/auth/service/AuthService.java
@@ -1,5 +1,10 @@
 package com.project.coalba.domain.auth.service;
 
+import com.project.coalba.domain.auth.entity.User;
+import com.project.coalba.domain.auth.entity.enums.Provider;
+import com.project.coalba.domain.auth.entity.enums.Role;
+import com.project.coalba.domain.auth.info.UserInfo;
+import com.project.coalba.domain.auth.info.UserInfoFactory;
 import com.project.coalba.domain.auth.repository.UserRefreshTokenRepository;
 import com.project.coalba.domain.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +19,20 @@ public class AuthService {
     private final UserRefreshTokenRepository userRefreshTokenRepository;
 
     @Transactional
-    public Object login() {
-        //TODO: 구글 or 네이버로부터 받아온 사용자 정보 저장 or 업데이트 후 token 발행
+    public Object login(Provider provider, String token, Role role) {
+        User socialUser = getSocialUser(provider, token, role), loginUser;
+        String providerId = socialUser.getProviderId();
+        boolean isNewUser;
+        if (isSubscribedUser(providerId)) {
+            loginUser = updateUser(socialUser);
+            isNewUser = false;
+        }
+        else {
+             loginUser = joinUser(socialUser);
+             isNewUser = true;
+        }
+
+        //TODO: token 발행 후 DTO 생성해서 반환
         return new Object();
     }
 
@@ -23,5 +40,24 @@ public class AuthService {
     public Object reissue() {
         //TODO: refresh token 유효성 검사 후 token 재발행
         return new Object();
+    }
+
+    private User getSocialUser(Provider provider, String token, Role role) {
+        UserInfo userInfo = UserInfoFactory.getUserInfo(provider);
+        return userInfo.getUser(token, role);
+    }
+
+    private boolean isSubscribedUser(String providerId) {
+        return userRepository.findByProviderId(providerId).isPresent(); //영속성 컨텍스트에서 관리X
+    }
+
+    private User updateUser(User socialUser) {
+        User loginUser = userRepository.findByProviderId(socialUser.getProviderId()).get();
+        loginUser.updateSocialInfo(socialUser);
+        return loginUser;
+    }
+
+    private User joinUser(User socialUser) {
+        return userRepository.save(socialUser);
     }
 }

--- a/src/main/java/com/project/coalba/domain/auth/service/AuthService.java
+++ b/src/main/java/com/project/coalba/domain/auth/service/AuthService.java
@@ -1,10 +1,17 @@
 package com.project.coalba.domain.auth.service;
 
+import com.project.coalba.domain.auth.repository.UserRefreshTokenRepository;
+import com.project.coalba.domain.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@RequiredArgsConstructor
 @Service
 public class AuthService {
+
+    private final UserRepository userRepository;
+    private final UserRefreshTokenRepository userRefreshTokenRepository;
 
     @Transactional
     public Object login() {

--- a/src/main/java/com/project/coalba/domain/auth/service/AuthService.java
+++ b/src/main/java/com/project/coalba/domain/auth/service/AuthService.java
@@ -1,0 +1,20 @@
+package com.project.coalba.domain.auth.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AuthService {
+
+    @Transactional
+    public Object login() {
+        //TODO: 구글 or 네이버로부터 받아온 사용자 정보 저장 or 업데이트 후 token 발행
+        return new Object();
+    }
+
+    @Transactional
+    public Object reissue() {
+        //TODO: refresh token 유효성 검사 후 token 재발행
+        return new Object();
+    }
+}

--- a/src/main/java/com/project/coalba/domain/auth/token/AuthTokenManager.java
+++ b/src/main/java/com/project/coalba/domain/auth/token/AuthTokenManager.java
@@ -1,0 +1,138 @@
+package com.project.coalba.domain.auth.token;
+
+import com.project.coalba.domain.auth.entity.User;
+import com.project.coalba.domain.auth.entity.UserPrincipal;
+import com.project.coalba.domain.auth.repository.UserRepository;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class AuthTokenManager {
+
+    @Value("${app.auth.accessTokenExpiry}")
+    private Long accessTokenExpiry;
+
+    @Value("${app.auth.refreshTokenExpiry}")
+    private Long refreshTokenExpiry;
+
+    private final Key key;
+    private final UserRepository userRepository;
+
+    private static final String USER_ID_KEY = "userId";
+
+    @Autowired
+    public AuthTokenManager(@Value("${app.auth.tokenSecret}") String secretKey, UserRepository userRepository) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+        this.userRepository = userRepository;
+    }
+
+    public String createAccessToken(String providerId, Long userId) {
+        Date expiryDate = getExpiryDate(accessTokenExpiry);
+        return createToken(providerId, userId, expiryDate);
+    }
+
+    public String createRefreshToken() {
+        Date expiryDate = getExpiryDate(refreshTokenExpiry);
+        return createToken(expiryDate);
+    }
+
+    private Date getExpiryDate(Long expiry) {
+        return new Date(System.currentTimeMillis() + expiry);
+    }
+
+    private String createToken(String providerId, Long userId, Date expiry) {
+        return Jwts.builder()
+                .setSubject(providerId)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .setIssuedAt(new Date())
+                .setExpiration(expiry)
+                .claim(USER_ID_KEY, userId)
+                .compact();
+    }
+
+    private String createToken(Date expiry) {
+        return Jwts.builder()
+                .signWith(key, SignatureAlgorithm.HS256)
+                .setIssuedAt(new Date())
+                .setExpiration(expiry)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        if (validate(token)) {
+            Claims claims = getTokenClaims(token);
+            Long userId = claims.get(USER_ID_KEY, Long.class);
+            Optional<User> userOptional = userRepository.findById(userId);
+
+            if (userOptional.isPresent()) {
+                User user = userOptional.get();
+                Collection<? extends GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(user.getRole().getCode()));
+                UserPrincipal principal = UserPrincipal.create(user);
+                return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+            }
+        }
+        return null;
+    }
+
+    public boolean validate(String token) {
+        return this.getTokenClaims(token) != null;
+    }
+
+    public Claims getTokenClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (SecurityException e) {
+            log.error("Invalid JWT signature.");
+        } catch (MalformedJwtException e) {
+            log.error("Invalid JWT token.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT token compact of handler are invalid");
+        }
+        return null;
+    }
+
+    public Claims getExpiredTokenClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token.");
+            return e.getClaims();
+        } catch (SecurityException e) {
+            log.error("Invalid JWT signature.");
+        } catch (MalformedJwtException e) {
+            log.error("Invalid JWT token.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT token compact of handler are invalid");
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/project/coalba/domain/auth/utils/HeaderUtil.java
+++ b/src/main/java/com/project/coalba/domain/auth/utils/HeaderUtil.java
@@ -1,0 +1,17 @@
+package com.project.coalba.domain.auth.utils;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class HeaderUtil {
+
+    private final static String HEADER_AUTHORIZATION = "Authorization";
+    private final static String TOKEN_PREFIX = "Bearer ";
+
+    public static String getAccessToken(HttpServletRequest request) {
+        String headerValue = request.getHeader(HEADER_AUTHORIZATION);
+        if (headerValue != null && headerValue.startsWith(TOKEN_PREFIX)) {
+            return headerValue.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
- 프론트에서 전달받은 access token으로 구글 or 네이버 사용자 정보 받아와 업데이트 or 저장
- token 발행 → API 요청 시 헤더에 포함
- access token 만료 시 유효한 refresh token으로 재발행

resolved #1 