### PR TITLE
refresh token 재발급 시기 수정

### DIFF
--- a/src/main/java/com/project/coalba/domain/auth/service/AuthService.java
+++ b/src/main/java/com/project/coalba/domain/auth/service/AuthService.java
@@ -92,7 +92,7 @@ public class AuthService {
     }
 
     private String issueRefreshToken(String originalRefreshToken) {
-        if (tokenManager.getRemainedValidSeconds(originalRefreshToken) <= REFRESH_TOKEN_CREATE_CRITERIA_SECONDS) {
+        if (tokenManager.getRemainedExpirySeconds(originalRefreshToken) <= REFRESH_TOKEN_CREATE_CRITERIA_SECONDS) {
             return tokenManager.createRefreshToken();
         }
         return originalRefreshToken;

--- a/src/main/java/com/project/coalba/domain/auth/service/AuthService.java
+++ b/src/main/java/com/project/coalba/domain/auth/service/AuthService.java
@@ -21,6 +21,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final UserRefreshTokenRepository userRefreshTokenRepository;
     private static final String USER_ID_KEY = "userId";
+    private static final long REFRESH_TOKEN_CREATE_CRITERIA_SECONDS = 2 * 24 * 60 * 60;
 
     @Transactional
     public AuthResponse login(Provider provider, Role role, String socialAccessToken, String socialRefreshToken) {
@@ -48,7 +49,7 @@ public class AuthService {
         UserRefreshToken userRefreshToken = getUserRefreshToken(userId).orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
         if (isValidRefreshToken(refreshToken, userRefreshToken.getToken())) {
             String newAccessToken = tokenManager.createAccessToken(providerId, userId);
-            String newRefreshToken = tokenManager.createRefreshToken();
+            String newRefreshToken = issueRefreshToken(refreshToken);
             userRefreshToken.updateToken(newRefreshToken);
             return new TokenResponse(newAccessToken, newRefreshToken);
         }
@@ -88,5 +89,12 @@ public class AuthService {
 
     private boolean isValidRefreshToken(String refreshToken, String dbRefreshToken) {
         return tokenManager.validate(refreshToken) && refreshToken.equals(dbRefreshToken);
+    }
+
+    private String issueRefreshToken(String originalRefreshToken) {
+        if (tokenManager.getRemainedValidSeconds(originalRefreshToken) <= REFRESH_TOKEN_CREATE_CRITERIA_SECONDS) {
+            return tokenManager.createRefreshToken();
+        }
+        return originalRefreshToken;
     }
 }

--- a/src/main/java/com/project/coalba/domain/auth/token/AuthTokenManager.java
+++ b/src/main/java/com/project/coalba/domain/auth/token/AuthTokenManager.java
@@ -5,15 +5,14 @@ import com.project.coalba.domain.auth.repository.UserRepository;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.*;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.*;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.time.*;
 import java.util.*;
 
 @Slf4j
@@ -133,5 +132,12 @@ public class AuthTokenManager {
             log.error(e.getMessage());
         }
         return null;
+    }
+
+    public long getRemainedValidSeconds(String token) {
+        LocalDateTime expiration = getTokenClaims(token).getExpiration()
+                .toInstant().atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+        return Duration.between(LocalDateTime.now(), expiration).getSeconds();
     }
 }

--- a/src/main/java/com/project/coalba/domain/auth/token/AuthTokenManager.java
+++ b/src/main/java/com/project/coalba/domain/auth/token/AuthTokenManager.java
@@ -21,11 +21,11 @@ public class AuthTokenManager {
     private final UserRepository userRepository;
     private final Key key;
 
-    @Value("${app.auth.accessTokenExpiry}")
-    private Long accessTokenExpiry;
+    @Value("${app.auth.accessToken.expiryPeriod}")
+    private Long accessTokenExpiryPeriod;
 
-    @Value("${app.auth.refreshTokenExpiry}")
-    private Long refreshTokenExpiry;
+    @Value("${app.auth.refreshToken.expiryPeriod}")
+    private Long refreshTokenExpiryPeriod;
 
     private static final String USER_ID_KEY = "userId";
 
@@ -36,34 +36,34 @@ public class AuthTokenManager {
     }
 
     public String createAccessToken(String providerId, Long userId) {
-        Date expiryDate = getExpiryDate(accessTokenExpiry);
+        Date expiryDate = getExpiryDate(accessTokenExpiryPeriod);
         return createToken(providerId, userId, expiryDate);
     }
 
     public String createRefreshToken() {
-        Date expiryDate = getExpiryDate(refreshTokenExpiry);
+        Date expiryDate = getExpiryDate(refreshTokenExpiryPeriod);
         return createToken(expiryDate);
     }
 
-    private Date getExpiryDate(Long expiry) {
-        return new Date(System.currentTimeMillis() + expiry);
+    private Date getExpiryDate(Long expiryPeriod) {
+        return new Date(System.currentTimeMillis() + expiryPeriod);
     }
 
-    private String createToken(String providerId, Long userId, Date expiry) {
+    private String createToken(String providerId, Long userId, Date expiryDate) {
         return Jwts.builder()
                 .setSubject(providerId)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .setIssuedAt(new Date())
-                .setExpiration(expiry)
+                .setExpiration(expiryDate)
                 .claim(USER_ID_KEY, userId)
                 .compact();
     }
 
-    private String createToken(Date expiry) {
+    private String createToken(Date expiryDate) {
         return Jwts.builder()
                 .signWith(key, SignatureAlgorithm.HS256)
                 .setIssuedAt(new Date())
-                .setExpiration(expiry)
+                .setExpiration(expiryDate)
                 .compact();
     }
 
@@ -134,10 +134,10 @@ public class AuthTokenManager {
         return null;
     }
 
-    public long getRemainedValidSeconds(String token) {
-        LocalDateTime expiration = getTokenClaims(token).getExpiration()
+    public long getRemainedExpirySeconds(String token) {
+        LocalDateTime expiryDateTime = getTokenClaims(token).getExpiration()
                 .toInstant().atZone(ZoneId.systemDefault())
                 .toLocalDateTime();
-        return Duration.between(LocalDateTime.now(), expiration).getSeconds();
+        return Duration.between(LocalDateTime.now(), expiryDateTime).getSeconds();
     }
 }


### PR DESCRIPTION
- 원래 refresh token은 access token 만료에 따라 refresh할 때마다 같이 재발급됨.
- 너무 무분별한 refresh token 재발급은 refresh token의 유효기간이 access token과 비슷하게 되도록 함. 
- 따라서 access token을 재발급할 때 refresh token의 만료 기간이 2일 이하로 남은 경우에만 refresh token도 재발급하고, 이외에는 기존 refresh token을 그대로 반환하도록 함.

resolved #37 