### PR TITLE
큰 버그까진 아니고 짜잘한 버그 해결 및 리팩토링 수행

### DIFF
--- a/src/main/java/com/project/coalba/domain/profile/repository/StaffProfileRepository.java
+++ b/src/main/java/com/project/coalba/domain/profile/repository/StaffProfileRepository.java
@@ -16,6 +16,6 @@ public interface StaffProfileRepository extends JpaRepository<Staff, Long>, Staf
     @Query("select s from Staff s join s.user u on u.email = :email")
     Optional<Staff> findByUserEmail(@Param("email") String email);
 
-    @Query("select s from Staff s inner join WorkspaceMember wm on s.id = wm.staff.id where wm.workspace.id = :workspaceId")
+    @Query("select s from Staff s inner join WorkspaceMember wm on s.id = wm.staff.id where wm.workspace.id = :workspaceId order by s.realName asc, s.id asc")
     List<Staff> findAllByWorkspaceId(@Param("workspaceId") Long workspaceId);
 }

--- a/src/main/java/com/project/coalba/domain/schedule/controller/BossScheduleController.java
+++ b/src/main/java/com/project/coalba/domain/schedule/controller/BossScheduleController.java
@@ -23,7 +23,6 @@ import java.util.*;
 @RestController
 public class BossScheduleController {
     private final BossScheduleService bossScheduleService;
-    private final ScheduleValidator scheduleValidator;
     private final ScheduleMapper mapper;
     private final ExternalCalendarService externalCalendarService;
 
@@ -63,7 +62,6 @@ public class BossScheduleController {
     @PostMapping
     public ResponseEntity<Void> saveSchedule(@Validated @RequestBody ScheduleCreateRequest scheduleCreateRequest) {
         ScheduleCreateServiceDto serviceDto = mapper.toServiceDto(scheduleCreateRequest);
-        scheduleValidator.validate(serviceDto); //schedule 생성 요청 검증
         Schedule schedule = bossScheduleService.save(serviceDto);
         externalCalendarService.addEvent(new CalendarDto(schedule)); //외부 api
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/com/project/coalba/domain/schedule/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/project/coalba/domain/schedule/repository/ScheduleRepositoryImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import java.time.*;
 import java.util.List;
 
+import static com.project.coalba.domain.profile.entity.QStaff.staff;
 import static com.project.coalba.domain.schedule.entity.QSchedule.*;
 
 @RequiredArgsConstructor
@@ -57,10 +58,10 @@ public class ScheduleRepositoryImpl implements ScheduleRepositoryCustom {
     public List<Schedule> findAllByWorkspaceIdAndDateFetch(Long workspaceId, LocalDate date) {
         LocalDateTime fromDateTime = getStartTimeOf(date), toDateTime = getEndTimeOf(date);
         return queryFactory.selectFrom(schedule)
-                .join(schedule.staff).fetchJoin()
+                .join(schedule.staff, staff).fetchJoin()
                 .where(schedule.workspace.id.eq(workspaceId),
                         schedule.scheduleStartDateTime.between(fromDateTime, toDateTime))
-                .orderBy(schedule.scheduleStartDateTime.asc(), schedule.scheduleEndDateTime.asc(), schedule.staff.realName.asc(), schedule.staff.id.asc())
+                .orderBy(schedule.scheduleStartDateTime.asc(), schedule.scheduleEndDateTime.asc(), staff.realName.asc(), staff.id.asc())
                 .fetch();
     }
 
@@ -68,10 +69,10 @@ public class ScheduleRepositoryImpl implements ScheduleRepositoryCustom {
     public List<Schedule> findAllByWorkspaceIdsAndDateFetch(List<Long> workspaceIds, LocalDate date) {
         LocalDateTime fromDateTime = getStartTimeOf(date), toDateTime = getEndTimeOf(date);
         return queryFactory.selectFrom(schedule)
-                .join(schedule.staff).fetchJoin()
+                .join(schedule.staff, staff).fetchJoin()
                 .where(schedule.workspace.id.in(workspaceIds),
                         schedule.scheduleStartDateTime.between(fromDateTime, toDateTime))
-                .orderBy(schedule.scheduleStartDateTime.asc(), schedule.scheduleEndDateTime.asc(), schedule.staff.realName.asc(), schedule.staff.id.asc())
+                .orderBy(schedule.scheduleStartDateTime.asc(), schedule.scheduleEndDateTime.asc(), staff.realName.asc(), staff.id.asc())
                 .fetch();
     }
 

--- a/src/main/java/com/project/coalba/domain/schedule/service/BossScheduleService.java
+++ b/src/main/java/com/project/coalba/domain/schedule/service/BossScheduleService.java
@@ -22,6 +22,7 @@ import static java.util.stream.Collectors.*;
 @RequiredArgsConstructor
 @Service
 public class BossScheduleService {
+    private final ScheduleValidator scheduleValidator;
     private final BossWorkspaceService bossWorkspaceService;
     private final StaffProfileService staffProfileService;
     private final ScheduleRepository scheduleRepository;
@@ -104,12 +105,12 @@ public class BossScheduleService {
 
     @Transactional
     public Schedule save(ScheduleCreateServiceDto serviceDto) {
+        scheduleValidator.validate(serviceDto); //schedule 생성 요청 검증
+
         Workspace workspace = bossWorkspaceService.getWorkspace(serviceDto.getWorkspaceId());
         Staff staff = staffProfileService.getStaff(serviceDto.getStaffId());
         Schedule schedule = serviceDto.toEntity(workspace, staff);
-        scheduleRepository.save(schedule);
-
-        return schedule;
+        return scheduleRepository.save(schedule);
     }
 
     @Transactional

--- a/src/main/java/com/project/coalba/domain/schedule/service/WorkReportService.java
+++ b/src/main/java/com/project/coalba/domain/schedule/service/WorkReportService.java
@@ -43,7 +43,7 @@ public class WorkReportService {
     @Transactional(readOnly = true)
     public Map<Integer, WorkReportServiceDto> getStaffWorkReportList(int year) {
         Map<Integer, List<Schedule>> monthlyScheduleList = getMyMonthlyScheduleListForYear(year);
-        Map<Integer, WorkReportServiceDto> monthlyWorkReport = new HashMap<>();
+        Map<Integer, WorkReportServiceDto> monthlyWorkReport = new LinkedHashMap<>();
 
         for (int month = getStartMonth(year); month <= getEndMonth(year); month++) {
             List<Schedule> scheduleList = monthlyScheduleList.get(month);
@@ -82,7 +82,7 @@ public class WorkReportService {
     public Map<Staff, WorkReportServiceDto> getBossWorkReportList(Long workspaceId, int year, int month) {
         Map<Long, List<Schedule>> scheduleListByStaff = getWorkspaceScheduleListByStaffForYearAndMonth(workspaceId, year, month);
         List<Staff> staffList = staffProfileService.getStaffListInWorkspace(workspaceId);
-        Map<Staff, WorkReportServiceDto> workReportByStaff = new HashMap<>();
+        Map<Staff, WorkReportServiceDto> workReportByStaff = new LinkedHashMap<>();
 
         for (Staff staff : staffList) {
             List<Schedule> scheduleList = scheduleListByStaff.get(staff.getId());

--- a/src/main/java/com/project/coalba/domain/workspace/controller/BossWorkspaceController.java
+++ b/src/main/java/com/project/coalba/domain/workspace/controller/BossWorkspaceController.java
@@ -8,7 +8,6 @@ import com.project.coalba.domain.workspace.service.BossWorkspaceService;
 import com.project.coalba.global.s3.AwsS3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
-import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/com/project/coalba/domain/workspace/repository/WorkspaceMemberRepository.java
+++ b/src/main/java/com/project/coalba/domain/workspace/repository/WorkspaceMemberRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember, Long> {
 
-    @Query("select wm from WorkspaceMember wm join fetch wm.staff where wm.workspace.id = :workspaceId order by wm.staff.realName asc, wm.staff.id asc")
+    @Query("select wm from WorkspaceMember wm join fetch wm.staff s where wm.workspace.id = :workspaceId order by s.realName asc, s.id asc")
     List<WorkspaceMember> findAllByWorkspaceIdFetch(@Param(("workspaceId")) Long workspaceId);
 
     @Query("select wm from WorkspaceMember wm where wm.workspace.id = :workspaceId and wm.staff.id = :staffId")


### PR DESCRIPTION
Boss 쪽 근무내역 및 알바비 관리 리스트 조회 api에서 아래와 같이 리스트 순서가 랜덤하게 조회됨.
```json
{
    "selectedWorkspaceId": 2,
    "selectedYear": 2022,
    "selectedMonth": 9,
    "workReportList": [
        {
	    "worker": {
                "workerId": 3,
                "name": "신지연",
                "imageUrl": "http://"
            },
	    "totalWorkTimeHour": 35,
	    "totalWorkTimeMin": 30,
	    "totalWorkPay": "320,600"
	},
	{
	    "worker": {
                "workerId": 5,
                "name": "김다은",
                "imageUrl": "http://"
            },
	    "totalWorkTimeHour": 35,
	    "totalWorkTimeMin": 30,
	    "totalWorkPay": "320,600"
	},
    ]
}
```

```json
{
    "selectedWorkspaceId": 2,
    "selectedYear": 2022,
    "selectedMonth": 9,
    "workReportList": [
        {
	    "worker": {
                "workerId": 5,
                "name": "김다은",
                "imageUrl": "http://"
            },
	    "totalWorkTimeHour": 35,
	    "totalWorkTimeMin": 30,
	    "totalWorkPay": "320,600"
	},
        {
	    "worker": {
                "workerId": 3,
                "name": "신지연",
                "imageUrl": "http://"
            },
	    "totalWorkTimeHour": 35,
	    "totalWorkTimeMin": 30,
	    "totalWorkPay": "320,600"
	},
    ]
}
```

입력한 순서가 보장되지 않는 `HashMap` 사용해서 발생하던 문제 → `LinkedHashMap` 사용하도록 변경 

resolved #51 (해당 이슈는 전체적으로 보니깐 내가 구현한 쪽에만 있어서 여기서 이슈 닫을께!)