### PR TITLE
profile, workspace imageUrl 값이 null이면 기본 이미지 url 반환하도록 구현

### DIFF
--- a/src/main/java/com/project/coalba/domain/profile/controller/StaffProfileController.java
+++ b/src/main/java/com/project/coalba/domain/profile/controller/StaffProfileController.java
@@ -8,7 +8,6 @@ import com.project.coalba.domain.profile.service.StaffProfileService;
 import com.project.coalba.global.s3.AwsS3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
-import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/com/project/coalba/domain/profile/entity/Boss.java
+++ b/src/main/java/com/project/coalba/domain/profile/entity/Boss.java
@@ -2,7 +2,9 @@ package com.project.coalba.domain.profile.entity;
 
 import com.project.coalba.domain.auth.entity.User;
 import com.project.coalba.global.audit.BaseTimeEntity;
+import com.project.coalba.global.utils.DefaultImageUtil;
 import lombok.*;
+import org.springframework.util.StringUtils;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -31,6 +33,11 @@ public class Boss extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", unique = true, nullable = false)
     private User user;
+
+    public String getImageUrl() {
+        if (!StringUtils.hasText(imageUrl)) return DefaultImageUtil.getProfileImageUrl();
+        return imageUrl;
+    }
 
     public void update(String realName, String phoneNumber, LocalDate birthDate, String imageUrl) {
         this.realName = realName;

--- a/src/main/java/com/project/coalba/domain/profile/entity/Staff.java
+++ b/src/main/java/com/project/coalba/domain/profile/entity/Staff.java
@@ -2,7 +2,9 @@ package com.project.coalba.domain.profile.entity;
 
 import com.project.coalba.domain.auth.entity.User;
 import com.project.coalba.global.audit.BaseTimeEntity;
+import com.project.coalba.global.utils.DefaultImageUtil;
 import lombok.*;
+import org.springframework.util.StringUtils;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -31,6 +33,11 @@ public class Staff extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", unique = true, nullable = false)
     private User user;
+
+    public String getImageUrl() {
+        if (!StringUtils.hasText(imageUrl)) return DefaultImageUtil.getProfileImageUrl();
+        return imageUrl;
+    }
 
     public void update(String realName, String phoneNumber, LocalDate birthDate, String imageUrl) {
         this.realName = realName;

--- a/src/main/java/com/project/coalba/domain/workspace/entity/Workspace.java
+++ b/src/main/java/com/project/coalba/domain/workspace/entity/Workspace.java
@@ -4,7 +4,9 @@ import com.project.coalba.domain.profile.entity.Boss;
 import com.project.coalba.domain.workspace.entity.enums.PayType;
 import com.project.coalba.domain.workspace.entity.enums.WorkType;
 import com.project.coalba.global.audit.BaseTimeEntity;
+import com.project.coalba.global.utils.DefaultImageUtil;
 import lombok.*;
+import org.springframework.util.StringUtils;
 
 import javax.persistence.*;
 
@@ -43,6 +45,11 @@ public class Workspace extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "boss_id", nullable = false)
     private Boss boss;
+
+    public String getImageUrl() {
+        if (!StringUtils.hasText(imageUrl)) return DefaultImageUtil.getWorkspaceImageUrl();
+        return imageUrl;
+    }
 
     public void update(String name, String phoneNumber, String address, String imageUrl) {
         this.name = name;

--- a/src/main/java/com/project/coalba/global/utils/DefaultImageUtil.java
+++ b/src/main/java/com/project/coalba/global/utils/DefaultImageUtil.java
@@ -1,0 +1,24 @@
+package com.project.coalba.global.utils;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultImageUtil {
+    private static String profileImageUrl;
+    private static String workspaceImageUrl;
+
+    private DefaultImageUtil(@Value("${profile.default.imageUrl}") String profileImageUrl,
+                             @Value("${workspace.default.imageUrl}") String workspaceImageUrl) {
+        DefaultImageUtil.profileImageUrl = profileImageUrl;
+        DefaultImageUtil.workspaceImageUrl = workspaceImageUrl;
+    }
+
+    public static String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+
+    public static String getWorkspaceImageUrl() {
+        return workspaceImageUrl;
+    }
+}


### PR DESCRIPTION
원래는 DB의 staff, boss, workspace 테이블 내 imageUrl 필드 기본값으로 기본 이미지 url을 저장하도록 구현하려고 했는데,
이렇게 되면 기본 이미지 url이 변동될 때마다 해당 테이블 내 imageUrl 필드를 모두 update 시켜줘야 하는 문제 발생! 
→ 차리리 imageUrl 필드값이 없으면 그냥 null 값으로 저장하고 api 응답 데이터를 getter를 통해 바인딩?할 때 `DefaultImageUtil` 클래스를 사용하여 imageUrl 값이 null이면 기본 이미지 url 반환하도록 구현함. (해당 기본 이미지 url은 application-aws.properties에 정의)

resolved #53 